### PR TITLE
Fallback if tool-chaing plugin not installed

### DIFF
--- a/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
+++ b/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
@@ -194,9 +194,10 @@ public class JPackageMojo extends AbstractMojo {
             addParameter(parameters, "--java-options", options);
         }
 
-        if (arguments != null && arguments.length > 0) {
-            String appArgs = String.join(" ", arguments);
-            addParameter(parameters, "--arguments", appArgs);
+        if (arguments != null) {
+            for (String argument : arguments) {
+                addParameter(parameters, "--arguments", argument);
+            }
         }
 
         if (isMac()) {

--- a/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
+++ b/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
@@ -231,7 +231,7 @@ public class JPackageMojo extends AbstractMojo {
         if (value == null || value.isEmpty()) {
             return;
         }
-        value = value.contains(" ") ? "\"" + value + "\"" : value;
+        value = "\"" + value.replace("\"", "\\\"") + "\"";
 
         getLog().info(name + " " + value);
         params.add(name);

--- a/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
+++ b/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
@@ -117,8 +117,15 @@ public class JPackageMojo extends AbstractMojo {
     private boolean linuxShortcut;
 
     public void execute() throws MojoExecutionException {
-        String jpackage = getJPackageExecutable();
-        getLog().info("Using: " + jpackage);
+        String jpackage;
+        try {
+            jpackage = getJPackageExecutable();
+            getLog().info("Using: " + jpackage);
+        } catch (Exception e) {
+            getLog().warn("Can't get jpackage location by toolchaing, trying with 'jpackage': " +
+                    e.getMessage());
+            jpackage = "jpackage";
+        }
 
         validateParameters();
 


### PR DESCRIPTION
Fallback to 'jpackage'  if tool-chaing plugin not installed and absolute jpackage location can't be find. This works if jpackage can be find by PATH/JAVA_HOME env variable.