### PR TITLE
Fix Maven config example in Documentation

### DIFF
--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -165,7 +165,9 @@ application jar. This example shows how to do this via ```maven-dependency-plugi
         <groupId>org.panteleyev</groupId>
         <artifactId>jpackage-maven-plugin</artifactId>
         <configuration>
-            <modulePath>target/jmods</modulePath>
+            <modulePaths>
+                <modulePath>target/jmods</modulePath>
+            </modulePaths>
         </configuration>
     </plugin>
 </plugins>


### PR DESCRIPTION
I was unable to run a config from Documentation, so looked at the code and found the issue in docs. I have not generated a website from it, only fixed the site sources.